### PR TITLE
Fix link within the document

### DIFF
--- a/draft-ietf-emu-rfc7170bis.md
+++ b/draft-ietf-emu-rfc7170bis.md
@@ -452,7 +452,7 @@ exchange described in [](#protected-termination).
 
 The TLV exchange includes the execution of zero or more inner
 methods within the protected tunnel as described in [](#inner-eap)
-and [](inner-password).  A server MAY proceed directly to the
+and [](#inner-password).  A server MAY proceed directly to the
 protected termination exchange, without performing any inner
 authentication if it does not wish to request further authentication
 from the peer.  A server MAY request one or more authentications


### PR DESCRIPTION
The link to #inner-password section was broken between draft revisions -02 and -03.